### PR TITLE
Fix websocket upgrade for Firefox users

### DIFF
--- a/gateway/mw_graphql.go
+++ b/gateway/mw_graphql.go
@@ -14,6 +14,7 @@ import (
 	gqlwebsocket "github.com/TykTechnologies/graphql-go-tools/pkg/subscription/websocket"
 
 	"github.com/TykTechnologies/tyk/internal/graphengine"
+	"github.com/TykTechnologies/tyk/internal/httputil"
 
 	"github.com/TykTechnologies/tyk/apidef"
 	"github.com/TykTechnologies/tyk/ctx"
@@ -183,7 +184,7 @@ func (m *GraphQLMiddleware) ProcessRequest(w http.ResponseWriter, r *http.Reques
 		return ProxyingRequestFailedErr, http.StatusInternalServerError
 	}
 
-	if websocket.IsWebSocketUpgrade(r) {
+	if upgradeType, upgrade := httputil.IsUpgrade(r); upgrade {
 		if !m.websocketUpgradeAllowed() {
 			return errors.New("websockets are not allowed"), http.StatusUnprocessableEntity
 		}

--- a/internal/httputil/streaming.go
+++ b/internal/httputil/streaming.go
@@ -23,8 +23,7 @@ func IsSseStreamingResponse(r *http.Response) bool {
 
 // IsUpgrade checks if the request is an upgrade request and returns the upgrade type.
 func IsUpgrade(req *http.Request) (string, bool) {
-	connection := strings.ToLower(strings.TrimSpace(req.Header.Get(headerConnection)))
-	if connection != "upgrade" {
+	if !headerContainsTokenIgnoreCase(req.Header, headerConnection, "Upgrade") {
 		return "", false
 	}
 
@@ -34,6 +33,28 @@ func IsUpgrade(req *http.Request) (string, bool) {
 	}
 
 	return "", false
+}
+
+func headerContainsTokenIgnoreCase(h http.Header, key, token string) bool {
+	for _, t := range headerTokens(h, key) {
+		if strings.EqualFold(t, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func headerTokens(h http.Header, key string) []string {
+	key = textproto.CanonicalMIMEHeaderKey(key)
+	var tokens []string
+	for _, v := range h[key] {
+		v = strings.TrimSpace(v)
+		for _, t := range strings.Split(v, ",") {
+			t = strings.TrimSpace(t)
+			tokens = append(tokens, t)
+		}
+	}
+	return tokens
 }
 
 // IsStreamingRequest returns true if the request designates streaming (gRPC or WebSocket).


### PR DESCRIPTION
Update the `IsUpgrade` function in `internal/httputil/streaming.go` to check if the `Connection` header contains "upgrade" instead of being exactly "upgrade".

Add a new test case `TestWebsockets` in `gateway/gateway_test.go` to verify that the connection header is upgraded and passed when 'Upgrade' is present with other data.

Update the `GraphQLMiddleware` in `gateway/mw_graphql.go` to use the updated `IsUpgrade` function to determine if a request is an upgrade request.
